### PR TITLE
Render Script Update sprite/particles/labels

### DIFF
--- a/main/main.render_script
+++ b/main/main.render_script
@@ -71,11 +71,11 @@ function update(self)
     render.enable_state(render.STATE_DEPTH_TEST)
     render.set_depth_mask(true)
     render.draw(self.model_pred)
+    render.disable_state(render.STATE_DEPTH_TEST)
+    render.disable_state(render.STATE_CULL_FACE)    
 
     -- debug rendering
     --
-    render.disable_state(render.STATE_DEPTH_TEST)
-    render.disable_state(render.STATE_CULL_FACE)    
     render.draw_debug3d()
 
     -- SPRITE + LABEL + PARTICLE 3d space
@@ -89,7 +89,6 @@ function update(self)
     render.disable_state(render.STATE_BLEND)
     render.disable_state(render.STATE_STENCIL_TEST)
     render.disable_state(render.STATE_DEPTH_TEST)
-    render.draw_debug3d()
     
     -- render GUI
     --

--- a/main/main.render_script
+++ b/main/main.render_script
@@ -62,19 +62,7 @@ function update(self)
 
     render.set_viewport(0, 0, render.get_window_width(), render.get_window_height())
     render.set_view(self.view)
-
-    render.set_depth_mask(false)
-    render.disable_state(render.STATE_DEPTH_TEST)
-    render.disable_state(render.STATE_STENCIL_TEST)
-    render.enable_state(render.STATE_BLEND)
-    render.set_blend_func(render.BLEND_SRC_ALPHA, render.BLEND_ONE_MINUS_SRC_ALPHA)
-    render.disable_state(render.STATE_CULL_FACE)
-
     render.set_projection(get_projection(self))
-
-    render.draw(self.tile_pred)
-    render.draw(self.particle_pred)
-    render.draw_debug3d()
 
     -- render models
     --
@@ -88,6 +76,19 @@ function update(self)
     --
     render.disable_state(render.STATE_DEPTH_TEST)
     render.disable_state(render.STATE_CULL_FACE)    
+    render.draw_debug3d()
+
+    -- SPRITE + LABEL + PARTICLE 3d space
+    --
+    render.set_blend_func(render.BLEND_SRC_ALPHA, render.BLEND_ONE_MINUS_SRC_ALPHA)
+    render.enable_state(render.STATE_DEPTH_TEST)
+    render.enable_state(render.STATE_STENCIL_TEST)
+    render.enable_state(render.STATE_BLEND)
+    render.draw(self.tile_pred)
+    render.draw(self.particle_pred)
+    render.disable_state(render.STATE_BLEND)
+    render.disable_state(render.STATE_STENCIL_TEST)
+    render.disable_state(render.STATE_DEPTH_TEST)
     render.draw_debug3d()
     
     -- render GUI


### PR DESCRIPTION
Changes rendering sprites, particles and labels in 3d pace with models. Fix to the current render script that draws sprites/particles/labels before models so they will not appear in 3d scenes obstructed by models.