### PR TITLE
[Modernize] Use `sys.get_config_number` instead of `sys.get_config`

### DIFF
--- a/main/main.render_script
+++ b/main/main.render_script
@@ -38,10 +38,10 @@ function init(self)
     self.model_pred = render.predicate({"model"})
     
     self.clear_color = vmath.vector4(0, 0, 0, 0)
-    self.clear_color.x = sys.get_config("render.clear_color_red", 0)
-    self.clear_color.y = sys.get_config("render.clear_color_green", 0)
-    self.clear_color.z = sys.get_config("render.clear_color_blue", 0)
-    self.clear_color.w = sys.get_config("render.clear_color_alpha", 0)
+    self.clear_color.x = sys.get_config_number("render.clear_color_red", 0)
+    self.clear_color.y = sys.get_config_number("render.clear_color_green", 0)
+    self.clear_color.z = sys.get_config_number("render.clear_color_blue", 0)
+    self.clear_color.w = sys.get_config_number("render.clear_color_alpha", 0)
 
     self.view = vmath.matrix4()
 


### PR DESCRIPTION
API Doc: https://defold.com/ref/stable/sys/#sys.get_config_number:key-[default_value]

Defold's note about deprecation: https://github.com/defold/defold/blob/cda1546407be1d3525c4f0340b582fb085e9b400/engine/script/src/script_sys.cpp#L1430